### PR TITLE
Action "state-leaving" behavior refactored

### DIFF
--- a/src/Menge/MengeCore/BFSM/Actions/Action.cpp
+++ b/src/Menge/MengeCore/BFSM/Actions/Action.cpp
@@ -50,8 +50,9 @@ namespace Menge {
 
 		void Action::onLeave( Agents::BaseAgent * agent ) {
 			if ( _undoOnExit ) {
-				leaveAction( agent );
+				resetAction(agent);
 			}
+			leaveAction(agent);
 		}
 
 		/////////////////////////////////////////////////////////////////////

--- a/src/Menge/MengeCore/BFSM/Actions/Action.cpp
+++ b/src/Menge/MengeCore/BFSM/Actions/Action.cpp
@@ -50,9 +50,9 @@ namespace Menge {
 
 		void Action::onLeave( Agents::BaseAgent * agent ) {
 			if ( _undoOnExit ) {
-				resetAction(agent);
+				resetAction( agent );
 			}
-			leaveAction(agent);
+			leaveAction( agent );
 		}
 
 		/////////////////////////////////////////////////////////////////////

--- a/src/Menge/MengeCore/BFSM/Actions/Action.h
+++ b/src/Menge/MengeCore/BFSM/Actions/Action.h
@@ -110,16 +110,25 @@ namespace Menge {
 			friend class ActionFactory;
 
 		protected:
-			/*! 
-			 *	@brief		The actual work to do upon exiting the state.
+
+			/*!
+			 *	@brief		The work to do when reseting an agent up on exit reset.   
+			 *				
+			 *	The reset action is guaranteed to be called *before* the general leave action, if
+			 *	the action has been configured to reset.
 			 *
-			 *	This is a purely virtual function.  Any Action sub-class must
-			 *	*explicitly* account for this function.  It will only be called if the
-			 *	action is set to undo its work upon exit.
+			 *	@param [in,out]	agent	If non-null, the action should take whatever actions are
+			 * 							necessary to reset the action's effects.
+			 */
+			virtual void resetAction( Agents::BaseAgent * agent ) {}
+
+			/*! 
+			 *	@brief		Work that will be done *unconditionally* when an agent leaves the state
+			 *				to which this action belongs.
 			 *
 			 *	@param		agent		The agent to act on.
 			 */
-			virtual void leaveAction( Agents::BaseAgent * agent ) = 0;
+			virtual void leaveAction(Agents::BaseAgent * agent) {};
 
 			/*!
 			 *	@brief		Determines if the action undoes itself on exiting the state.

--- a/src/Menge/MengeCore/BFSM/Actions/Action.h
+++ b/src/Menge/MengeCore/BFSM/Actions/Action.h
@@ -117,7 +117,7 @@ namespace Menge {
 			 *	The reset action is guaranteed to be called *before* the general leave action, if
 			 *	the action has been configured to reset.
 			 *
-			 *	@param [in,out]	agent	If non-null, the action should take whatever actions are
+			 *	@param[in,out]	agent	If non-null, the action should take whatever actions are
 			 * 							necessary to reset the action's effects.
 			 */
 			virtual void resetAction( Agents::BaseAgent * agent ) {}
@@ -128,7 +128,7 @@ namespace Menge {
 			 *
 			 *	@param		agent		The agent to act on.
 			 */
-			virtual void leaveAction(Agents::BaseAgent * agent) {};
+			virtual void leaveAction( Agents::BaseAgent * agent ) {};
 
 			/*!
 			 *	@brief		Determines if the action undoes itself on exiting the state.

--- a/src/Menge/MengeCore/BFSM/Actions/ObstacleAction.cpp
+++ b/src/Menge/MengeCore/BFSM/Actions/ObstacleAction.cpp
@@ -69,7 +69,7 @@ namespace Menge {
 
 		/////////////////////////////////////////////////////////////////////
 
-		void ObstacleAction::leaveAction( Agents::BaseAgent * agent ) {
+		void ObstacleAction::resetAction( Agents::BaseAgent * agent ) {
 			_lock.lock();
 			std::map< size_t, size_t >::iterator itr = _originalMap.begin();
 			assert( itr != _originalMap.end() && "Trying to find an original value for an agent whose value was not cached" );

--- a/src/Menge/MengeCore/BFSM/Actions/ObstacleAction.h
+++ b/src/Menge/MengeCore/BFSM/Actions/ObstacleAction.h
@@ -98,7 +98,7 @@ namespace Menge {
 			 *
 			 *	@param		agent		The agent to act on.
 			 */
-			virtual void leaveAction( Agents::BaseAgent * agent );
+			virtual void resetAction( Agents::BaseAgent * agent );
 
 			/*!
 			 *	@brief		Computes the new property value given the original property value.

--- a/src/Menge/MengeCore/BFSM/Actions/PropertyAction.h
+++ b/src/Menge/MengeCore/BFSM/Actions/PropertyAction.h
@@ -105,7 +105,7 @@ namespace Menge {
 			 *
 			 *	@param		agent		The agent to act on.
 			 */
-			virtual void leaveAction( Agents::BaseAgent * agent ) { _manip.restore( agent ); }
+			virtual void resetAction( Agents::BaseAgent * agent ) { _manip.restore( agent ); }
 
 			/*!
 			 *	@brief		The manipulator responsible for changing agent properties.

--- a/src/Menge/MengeCore/BFSM/Actions/TeleportAction.h
+++ b/src/Menge/MengeCore/BFSM/Actions/TeleportAction.h
@@ -93,13 +93,6 @@ namespace Menge {
 		protected:
 
 			/*!
-			 *	@brief		The work to do upon state exit.
-			 *
-			 *	@param		agent		The agent to act on.
-			 */
-			virtual void leaveAction( Agents::BaseAgent * agent ) {}
-
-			/*!
 			 *	@brief		The generator for computing teleport destination locations.
 			 */
 			Vec2DGenerator * _goals;


### PR DESCRIPTION
When an agent leaves a state, the action allows for a boolean "reset".
This change allows a more general change.  Specifically, upon exiting
the parent state, the action class can do two things: one is dependent
on the reset flag (formerly called "leaveAction", now called "resetAction")
and another action which will be invoked unconditionally (the new
"leaveAction".  It is guaranteed that the resetAction will be invoked
*before* the the leaveAction (if invoked at all).