### PR TITLE
Patch project

### DIFF
--- a/src/Menge/MengeCore/ProjectSpec.h
+++ b/src/Menge/MengeCore/ProjectSpec.h
@@ -278,7 +278,7 @@ namespace Menge {
      *	@param		spec		A ProjectSpec
      *	@returns	A reference to the output stream
      */
-    friend Logger& operator<<( Logger& out, const ProjectSpec& spec );
+    friend MENGE_API Logger& operator<<( Logger& out, const ProjectSpec& spec );
 
   private:
     /*!


### PR DESCRIPTION
In moving the `Logger& operator<<`  method into Menge namespace. I had broken a piece of MSVC functionality. It was no longer exported from the dll, so `mengeMain.cpp` couldn't access the function. This explicitly exports the method so it is available.