### PR TITLE
Remove superfluous trailing backslash in userProps

### DIFF
--- a/projects/VS2013/pluginMacros.props
+++ b/projects/VS2013/pluginMacros.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" >
-    <MengeSrc>$(SolutionDir)..\..\..\src\Menge\</MengeSrc>
+    <MengeSrc>$(SolutionDir)..\..\..\src\Menge</MengeSrc>
     <MengeLib>$(SolutionDir)..\Menge\build\lib</MengeLib>
     <PluginSrc>$(SolutionDir)..\..\..\src\Plugins</PluginSrc>
   </PropertyGroup>

--- a/projects/VS2015/pluginMacros.props
+++ b/projects/VS2015/pluginMacros.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" >
-    <MengeSrc>$(SolutionDir)..\..\..\src\Menge\</MengeSrc>
+    <MengeSrc>$(SolutionDir)..\..\..\src\Menge</MengeSrc>
     <MengeLib>$(SolutionDir)..\Menge\build\lib</MengeLib>
     <PluginSrc>$(SolutionDir)..\..\..\src\Plugins</PluginSrc>
   </PropertyGroup>


### PR DESCRIPTION
The definition of $MengeSrc in pluginMacros.props had a trailing back
slash. Apparently, this can cause problems in some configurations of
visual studio/windows.