### PR TITLE
Extend C-wrapper

### DIFF
--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -21,6 +21,9 @@ Release 0.9.2
 			profile from a *weighted* set. The probability of selecting a particular profile is
 			proportional to its relative weight in the set.
 			- Adds a new demo (profileSelect) to illustrate how to use the new selectors.
+		C-wrapper
+			- Added per-agent preferred velocity and state id.
+			- Added state introspection (number and names of states).
 
 ----------------------------------------------------------------
 Release 0.9.1

--- a/src/Menge/MengeCore/BFSM/State.h
+++ b/src/Menge/MengeCore/BFSM/State.h
@@ -238,7 +238,7 @@ namespace Menge {
 			 *
 			 *	@returns	The state's name.
 			 */
-			std::string getName() const { return _name; }
+			const std::string& getName() const { return _name; }
 
 			/*!
 			 *	@brief		Returns the number of agents in this state.

--- a/src/Menge/MengeCore/menge_c_api.cpp
+++ b/src/Menge/MengeCore/menge_c_api.cpp
@@ -4,6 +4,7 @@
 #include "MengeCore/Agents/Events/EventSystem.h"
 #include "MengeCore/Agents/SimulatorInterface.h"
 #include "MengeCore/BFSM/FSM.h"
+#include "MengeCore/BFSM/State.h"
 #include "MengeCore/Core.h"
 #include "MengeCore/PluginEngine/CorePluginEngine.h"
 #include "MengeCore/Runtime/SimulatorDB.h"
@@ -64,6 +65,26 @@ extern "C" {
 
 	/////////////////////////////////////////////////////////////////////
 
+	const char* GetStateName(size_t state_id) {
+		assert(_simulator != nullptr);
+		Menge::BFSM::FSM* bfsm = _simulator->getBFSM();
+		if (state_id < bfsm->getNodeCount()) {
+			Menge::BFSM::State* state = bfsm->getNode(state_id);
+			return state->getName().c_str();
+		}
+		return nullptr;
+	}
+
+	/////////////////////////////////////////////////////////////////////
+
+	size_t StateCount() {
+		assert(_simulator != nullptr);
+		Menge::BFSM::FSM* bfsm = _simulator->getBFSM();
+		return bfsm->getNodeCount();
+	}
+
+	/////////////////////////////////////////////////////////////////////
+
 	size_t  AgentCount() {
 		assert(_simulator != 0x0);
 		return _simulator->getNumAgents();
@@ -92,6 +113,33 @@ extern "C" {
 			*x = agt->_vel._x;
 			*y = 0; // get elevation
 			*z = agt->_vel._y;
+			return true;
+		}
+		return false;
+	}
+
+	/////////////////////////////////////////////////////////////////////
+
+	bool GetAgentPrefVelocity(size_t i, float* x, float* y) {
+		assert(_simulator != nullptr);
+		Menge::Agents::BaseAgent* agt = _simulator->getAgent(i);
+		if (agt != nullptr) {
+			const auto& vel_pref = agt->_velPref.getPreferredVel();
+			*x = vel_pref._x;
+			*y = vel_pref._y;
+			return true;
+		}
+		return false;
+	}
+
+	/////////////////////////////////////////////////////////////////////
+
+	bool GetAgentState(size_t i, size_t* state_id) {
+		assert(_simulator != nullptr);
+		Menge::Agents::BaseAgent* agt = _simulator->getAgent(i);
+		if (agt != nullptr) {
+			const auto* bfsm = _simulator->getBFSM();
+			*state_id = bfsm->getAgentStateID(agt->_id);
 			return true;
 		}
 		return false;

--- a/src/Menge/MengeCore/menge_c_api.h
+++ b/src/Menge/MengeCore/menge_c_api.h
@@ -65,6 +65,24 @@ extern "C" {
 
 	//@}
 
+	/*! @name       FSM introspection */
+	//@{
+
+	/*!
+	 *	@brief		Reports the name of the state with the given id.
+	 *	@param		state_id	The id of the desired state.
+	 *	@returns	A pointer to the c-string of the state's name. Nullptr if state_id does not
+	 *				refer to a valid state.
+	 */
+	MENGE_API const char* GetStateName(size_t state_id);
+
+	/*!
+	 *	@brief		Reports the number of states in the BFSM.
+	 */
+	MENGE_API size_t StateCount();
+
+	//@}
+
 	/*!	@name		Agent functions
 	 *	@brief		Functions for querying the state of the simulator agents.
 	 */
@@ -98,6 +116,24 @@ extern "C" {
 	 *	@returns			True if the values were successfully set.
 	 */
 	MENGE_API bool  GetAgentVelocity( size_t i, float * x, float * y, float * z );
+
+	/*!
+	 *	@brief		Reports the 2D preferred velocity of the indicated agent.
+	 *	@param		i		The index of the desired agent.
+	 *	@param[out] x		The preferred velocity's x-component.
+	 *	@param[out] y		The preferred velocity's y-component.
+	 *	@returns			True if the values were successfully set.
+	 */
+	MENGE_API bool GetAgentPrefVelocity(size_t i, float* x, float*y);
+
+	/*!
+	 *	@brief		Reports the id of the state the indicated agent is currently in.
+	 *
+	 *	@param		i			The index of the desired agent.
+	 *	@param[out]	state_id	The id of the state the agent is currently in.
+	 *	@returns				True if the values were successfully set.
+	 */
+	MENGE_API bool GetAgentState(size_t i, size_t* state_id);
 
 	/*!
 	 *	@brief		Reports the 2D orientation of the indicated agent.  It is the facing direction


### PR DESCRIPTION
This adds some needed features to the C-wrapper

1. Per-agent preferred velocity and state id.
2. Ability to query the name of a state and the total number of states.

Incidentally, required a minor patch on `Menge::BFSM::State::getName()`; the return type now returns a `const` ref to the state's name rather than a copy. This allows me to send back a `const char*` that persists as long as the simulator does.