### PR TITLE
Corrected messages in EventEffectAgentState

### DIFF
--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -1,6 +1,6 @@
 ----------------------------------------------------------------
 Release 0.9.2
-	???? ??, 2017
+	???? ??, 2018
 	
 	Features
 		Moved `ProjectSpec` out of main menge application and into core library
@@ -17,6 +17,7 @@ Release 0.9.2
 	Bugs
 		VelCompRoadmap would allow agents to get stuck if they were pushed far enough away from 
 		their path. Fixed is to detect this happening and replanning.
+		Minor patch in EventEffectAgentStateFactory; corrected error messages.
 
 ----------------------------------------------------------------
 Release 0.9.1

--- a/src/Menge/MengeCore/Agents/Events/EventEffectAgentState.cpp
+++ b/src/Menge/MengeCore/Agents/Events/EventEffectAgentState.cpp
@@ -62,7 +62,7 @@ namespace Menge {
 	bool EventEffectAgentStateFactory::setFromXML(EventEffect * effect, TiXmlElement * node,
 		const std::string & behaveFldr) const {
 		EventEffectAgentState * aEffect = dynamic_cast< EventEffectAgentState * >(effect);
-		assert(aEffect != 0x0 && "Trying to set agent event effect properties on an "
+		assert(aEffect != 0x0 && "Trying to set agent state event effect on an "
 			"incompatible object");
 
 		// This parses the target
@@ -70,7 +70,7 @@ namespace Menge {
 
 		// Extract the StateSelector from the XML.
 		auto selectorNode = node->FirstChildElement("StateSelector");
-		assert(selectorNode != nullptr && "The set_agent_property event effect requries a "
+		assert(selectorNode != nullptr && "The 'set_agent_state' event effect requries a "
 			"StateSelector child.");
 		
 		aEffect->_selector = StateSelectorDB::getInstance(selectorNode, behaveFldr);


### PR DESCRIPTION
In passing, I noticed an error was suffering from copypasta. I updated it to provide the correct feedback. This correction does not imply that *all* error messages are correct, just that this one is no longer wrong.