### PR TITLE
Bugfix - create road map path for agents in collision

### DIFF
--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -5,6 +5,8 @@ Release 0.9.3
     Bug fixes
         OBBShape had inconsistent definitions for getXBasis() and getYBasis().
             Documentation clarified, usage unified.
+		RoadMap velocity component couldn't create a path for agents who were in collision with an
+		    obstacle. Addressed in [PR 118](https://github.com/MengeCrowdSim/Menge/pull/118)
 	
 	Features
 		State population event trigger - upgrade the event triggers that depend on state population.

--- a/src/Menge/MengeCore/Agents/SimulatorInterface.cpp
+++ b/src/Menge/MengeCore/Agents/SimulatorInterface.cpp
@@ -137,13 +137,6 @@ namespace Menge {
 
 		////////////////////////////////////////////////////////////////
 
-		bool SimulatorInterface::queryVisibility( const Vector2& point1, const Vector2& point2,
-												  float radius ) const {
-			return _spatialQuery->queryVisibility( point1, point2, radius );
-		}
-
-		////////////////////////////////////////////////////////////////
-
 		void SimulatorInterface::finalize() {
 			if ( _fsm == 0x0 ) throw BFSM::FSMFatalException( "No BFSM defined for simulation." );
 			if ( _elevation == 0x0 ) {

--- a/src/Menge/MengeCore/Agents/SimulatorInterface.h
+++ b/src/Menge/MengeCore/Agents/SimulatorInterface.h
@@ -190,26 +190,6 @@ namespace Menge {
 			bool hasSpatialQuery() const { return _spatialQuery != 0x0; }
 
 			/*!
-			 *  @brief      Performs a visibility query between the two specified
-			 *              points with respect to the obstacles.
-			 *
-			 *	The obstacles are one-sided.  So, the ordering of point1 and point2 matter.
-			 *	Looking from the inside out is not equivalent to looking from the outside in.
-			 *
-			 *  @param      point1          The first point of the query.
-			 *  @param      point2          The second point of the query.
-			 *  @param      radius          The minimal distance between the line
-			 *                              connecting the two points and the obstacles
-			 *                              in order for the points to be mutually
-			 *                              visible (optional). Must be non-negative.
-			 *  @returns    A boolean specifying whether the two points are mutually
-			 *              visible. Returns true when the obstacles have not been
-			 *              processed.
-			 */
-			bool queryVisibility( const Math::Vector2 & point1, const Math::Vector2 & point2,
-								  float radius = 0.0f ) const;
-
-			/*!
 			 *  @brief      Returns the global time of the simulation.
 			 *
 			 *  @returns    The present global time of the simulation (zero initially).

--- a/src/Menge/MengeCore/Agents/SpatialQueries/ObstacleKDTree.h
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/ObstacleKDTree.h
@@ -96,6 +96,10 @@ namespace Menge {
 			 */
 			void obstacleQuery( ProximityQuery *query) const;
 
+      /*! @brief  Implementation of SpatialQuery::linkIsTraversible().  */
+      bool linkIsTraversible(const Math::Vector2& q1, const Math::Vector2& q2,
+                             float radius) const;
+
 			/*!
 			 *  @brief      Queries the visibility between two points within a
 			 *              specified radius.
@@ -134,6 +138,9 @@ namespace Menge {
 			void queryTreeRecursive( ProximityQuery *query, Math::Vector2 pt, float& rangeSq,
 									 const ObstacleTreeNode* node ) const;
 
+      /*! @brief  Implementation of linkIsTraversible() via recursion.  */
+      bool linkIsTraversibleRecursive(const Math::Vector2& q1, const Math::Vector2& q2,
+                                      float radius, const ObstacleTreeNode* node) const;
 			/*!
 			 *	@brief		Perform the work, recursively, to determine if q1 can see q2, w.r.t.
 			 *				the obstacles.

--- a/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQuery.h
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQuery.h
@@ -158,6 +158,37 @@ namespace Menge {
 			 */
 			virtual void obstacleQuery( ProximityQuery * query) const = 0;
 
+      /*!
+       @brief  Reports if an agent can traverse the straight-line path from `q1` to `q2`.
+
+       This query performs a per-obstacle test to determine if the obstacle limits traversibility.
+       This test is closely related to an intersection test between a line segment (an individual
+       obstacle) and a capsule (the traversible link between `q1` and `q2` convolved with a disk of
+       the given `radius`). Generally, if the line segment intersects the link, the link is _not_
+       traversible. However, this isn't universally true.
+
+       First, obstacles have "sides". An obstacle doesn't obstruct if the path from `q1` to `q2
+       passes from _inside_ the obstacle to _outside_ the obstacle.
+
+       Second, even an agent whose center lies _outside_ an obstacle (but otherwise intersects the
+       obstacle) may not be considered obstructed. This query link represents the path of an agent.
+       We cannot guarantee that the starting position is collision free. As such, an obstacle might
+       intersect the capsule in an otherwise meaningless way. These meaningless collisions do not
+       prevent the link from being traversible.
+
+       To be a "meaningless" collision the following must be true:
+
+         - The line segment must intersect a circle centered at `q1` with the given `radius`.
+         - The direction of the link (`q2 - q1`) must point _away_ from the line segment.
+
+      @param  q1      The start point of the link to be tested.
+      @param  q2      The end point of the link to be tested.
+      @param  radius  The radius of the agent to traverse the link.
+      @returns  True if the link is deemed a traversible path.
+      */
+      virtual bool linkIsTraversible(const Math::Vector2& q1, const Math::Vector2& q2,
+                                     float radius) const = 0;
+
 			/*!
 			 *  @brief      Queries the visibility between two points within a
 			 *              specified radius.

--- a/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryKDTree.h
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryKDTree.h
@@ -98,6 +98,12 @@ namespace Menge {
 				_obstTree.obstacleQuery( query);
 			}
 
+      /*! @brief  Implementation of SpatialQuery::linkIsTraversible().  */
+      bool linkIsTraversible(const Math::Vector2& q1, const Vector2& q2, float radius) const
+        override {
+        return _obstTree.linkIsTraversible(q1, q2, radius);
+      }
+
 			/*!
 			 *  @brief      Queries the visibility between two points within a
 			 *              specified radius.

--- a/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.cpp
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.cpp
@@ -329,6 +329,7 @@ namespace Menge {
 
 		bool NavMeshSpatialQuery::queryVisibility(const Vector2& q1, const Vector2& q2,
 												   float radius) const {
+      // TODO(curds01): Not implemented.
 			return true;
 		}
 

--- a/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.cpp
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.cpp
@@ -325,6 +325,12 @@ namespace Menge {
 			}	
 		}
 
+    bool NavMeshSpatialQuery::linkIsTraversible(const Math::Vector2& q1, const Vector2& q2,
+                                                float radius) const {
+      // TODO(curds01): Not implemented.
+      return true;
+    }
+
 		////////////////////////////////////////////////////////////////
 
 		bool NavMeshSpatialQuery::queryVisibility(const Vector2& q1, const Vector2& q2,

--- a/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.h
+++ b/src/Menge/MengeCore/Agents/SpatialQueries/SpatialQueryNavMesh.h
@@ -98,6 +98,9 @@ namespace Menge {
 			 */
 			virtual void obstacleQuery( ProximityQuery *query, float rangeSq) const;
 
+      /*! @brief  Implementation of SpatialQuery::linkIsTraversible().  */
+      bool linkIsTraversible(const Math::Vector2& q1, const Vector2& q2, float radius) const
+        override;
 
 			/*!
 			 *  @brief      Queries the visibility between two points within a

--- a/src/Menge/MengeCore/BFSM/VelocityComponents/VelCompRoadMap.cpp
+++ b/src/Menge/MengeCore/BFSM/VelocityComponents/VelCompRoadMap.cpp
@@ -107,8 +107,11 @@ namespace Menge {
 				_lock.releaseRead();
 				// compute the path and add it to the map
 				//	Create path for the agent
-				Vector2 goalPoint = goal->getCentroid();
-				path = _roadmap->getPath( agent, goal ); 
+				path = _roadmap->getPath( agent, goal );
+        if (path == nullptr) {
+          throw VelCompFatalException("Agent " + std::to_string(agent->_id) + 
+                                      " was unable to find a path to its goal");
+        }
 				_lock.lockWrite();
 				_paths[ agent->_id ] = path;
 				_lock.releaseWrite();
@@ -123,8 +126,12 @@ namespace Menge {
 				delete path;
 				Vector2 goalPoint = goal->getCentroid();
 				path = _roadmap->getPath(agent, goal);
-				// While this operation doesn't change the structure of the map (agent->_id is already a key),
-				// we lock it to prevent any *other* write operation from interfering.
+        if (path == nullptr) {
+          throw VelCompFatalException("Agent " + std::to_string(agent->_id) + 
+                                      " lost roadmap path and was unable to create a new path");
+        }
+				// While this operation doesn't change the structure of the map (agent->_id is already a
+        // key), we lock it to prevent any *other* write operation from interfering.
 				_lock.lockWrite();
 				_paths[agent->_id] = path;
 				_lock.releaseWrite();

--- a/src/Menge/MengeCore/BFSM/VelocityComponents/VelCompRoadMap.h
+++ b/src/Menge/MengeCore/BFSM/VelocityComponents/VelCompRoadMap.h
@@ -126,6 +126,7 @@ namespace Menge {
 			 *	@param		agent		The agent for which a preferred velocity is computed.
 			 *	@param		goal		The agent's goal (although this may be ignored).
 			 *	@param		pVel		The instance of Agents::PrefVelocity to set.
+       *  @throws   VelCompFatalException if a path cannot be found from agent position to goal.
 			 */
 			virtual void setPrefVelocity( const Agents::BaseAgent * agent, const Goal * goal,
 										  Agents::PrefVelocity & pVel ) const;

--- a/src/Menge/MengeCore/Math/Vector2.h
+++ b/src/Menge/MengeCore/Math/Vector2.h
@@ -567,8 +567,9 @@ namespace Menge {
 													   float threshSqd );
 
 		/*! 
-		 *  @brief      Computes the signed distance from a line connecting the
-		 *              specified points to a specified point.
+		 *  @brief      Computes the _scaled_ signed distance from a line connecting the
+		 *              specified points to a specified point. The scale is the length of the line
+     *              segment defined by a and b.
 		 *  @param      a               The first point on the line.
 		 *  @param      b               The second point on the line.
 		 *  @param      c               The point to which the signed distance is to

--- a/src/Menge/MengeCore/resources/Graph.h
+++ b/src/Menge/MengeCore/resources/Graph.h
@@ -98,7 +98,7 @@ namespace Menge {
 		 *	@param		agent		The agent for whom to compute the path.
 		 *	@param		goal		The agent's goal.
 		 *	@returns	A pointer to a RoadMapPath.  If there is an error,
-		 *				the poitner will be NULL.
+		 *				the pointer will be NULL.
 		 */
 		RoadMapPath * getPath( const Agents::BaseAgent * agent, const BFSM::Goal * goal );
 
@@ -127,16 +127,22 @@ namespace Menge {
 		static const std::string LABEL;
 
 	protected:
+    /** Definition of the amount of clearance required in connecting a vertex to the graph.  */
+    enum class Clearance {
+      Partial,  ///< Connection need only be traversible (see SpatialQuery::linkIsTraversible()).
+      Full      ///< Connection must be fully _visible_ (see SpatialQuery::queryVisibility()).
+    };
 
 		/*!
 		 *	@brief		Find the closest visible graph vertex to the given
 		 *				point.
 		 *
-		 *	@param		point		The point to connect to the graph.
-		 *	@param		radius		The radius of the agent testing.
-		 *	@returns	The index of the closest node.
+		 *	@param		point		   The point to connect to the graph.
+		 *	@param		radius		 The radius of the agent testing.
+     *  @param    clearance  The type of clearance required for connecting point to the graph.
+		 *	@returns	The index of the closest node (-1 if no node can be connected).
 		 */
-		size_t getClosestVertex( const Vector2 & point, float radius );
+		size_t getClosestVertex( const Vector2 & point, float radius, Clearance clearance);
 
 		/*!
 		 *	@brief		Computes the shortest path from start to end vertices.

--- a/src/Menge/MengeCore/resources/RoadMapPath.cpp
+++ b/src/Menge/MengeCore/resources/RoadMapPath.cpp
@@ -92,24 +92,30 @@ namespace Menge {
 		// TODO: Should I compute this blindly?  Although it is used in potentially three places
 		//		mostly, it won't be used.
 		Vector2 target = _goal->getTargetPoint( agent->_pos, agent->_radius );
+
+    // First confirm I can still see the point I'm headed toward.
 		if ( _targetID < _wayPointCount ) {
 			isVisible =
-				Menge::SPATIAL_QUERY->queryVisibility( agent->_pos, _wayPoints[ _targetID ],
+				Menge::SPATIAL_QUERY->linkIsTraversible( agent->_pos, _wayPoints[ _targetID ],
 				agent->_radius );
 		} else {
-			isVisible = Menge::SPATIAL_QUERY->queryVisibility( agent->_pos, target,
+			isVisible = Menge::SPATIAL_QUERY->linkIsTraversible( agent->_pos, target,
 															   agent->_radius );
 		}
+
+    // See if I can't advance my current waypoint to one further along my path.
 		size_t testID = _targetID + 1;
+    // TODO(curds01): Should I be advancing the counter if the current isn't visible? If so, justify
+    // this.
 		while ( testID < _wayPointCount &&
-				Menge::SPATIAL_QUERY->queryVisibility( agent->_pos, _wayPoints[ testID ],
+				Menge::SPATIAL_QUERY->linkIsTraversible( agent->_pos, _wayPoints[ testID ],
 				agent->_radius ) ) {
 			_targetID = testID;
 			isVisible = true;
 			++testID;
 		}
 		if ( _targetID == _wayPointCount - 1 ) {
-			if ( Menge::SPATIAL_QUERY->queryVisibility( agent->_pos, target, agent->_radius ) ) {
+			if ( Menge::SPATIAL_QUERY->linkIsTraversible( agent->_pos, target, agent->_radius ) ) {
 				++_targetID;
 				isVisible = true;
 			}
@@ -122,7 +128,7 @@ namespace Menge {
 			_validPos = agent->_pos;
 			pVel.setTarget( curr );
 		} else {
-			if (Menge::SPATIAL_QUERY->queryVisibility(agent->_pos, _validPos, agent->_radius)) {
+			if (Menge::SPATIAL_QUERY->linkIsTraversible(agent->_pos, _validPos, agent->_radius)) {
 				// This should never be the zero vector.
 				//	_validPos is set when the current waypoint is visible
 				//  this code is only achieved when it is NOT visible


### PR DESCRIPTION
The process of finding a path on a roadmap for an agent consists of finding "visible" links from the agent position to a road map vertex. The visibility query w.r.t. a *single* obstacle essentially tests for
intersection between the obstacle's line segment and a capsule formed by the desired link (agent position to vertex position) convolved with a disk of the agent's radius. For a given vertex, if any obstacle intersects the vertex is not "visible". If the agent is intersecting an obstacle, no vertex will be considered visible.

The fix:
  1. Add new query to SpatialQuery; linkIsTraversible(). It is closely      related to the queryVsibility() method with one extra detail; it handles the case where the agent is intersecting an obstacle.
  2. Extend the API through the two implementations of the interface (the nav mesh implementation is *not* implemented at all.) The kd-tree implementaiton is, essentially, a copy of the visibility query with the last test modified.
  3. Change the calls in the roadmap from visibility to traversibility.
  4. Add some stray clarifying comments.
  5. Remove asserts and replace them with more appropriate exceptions.

NOTE: tragically, the test framework is not sufficiently solid to admit the easy inclusion of unit tests on this.  :( 

Resolves #116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mengecrowdsim/menge/118)
<!-- Reviewable:end -->
